### PR TITLE
fix: highlights should have default attribute

### DIFF
--- a/import/Vim9SyntaxUtil.vim
+++ b/import/Vim9SyntaxUtil.vim
@@ -27,7 +27,7 @@ export def Derive(
     if from_def->get('cleared')
         return
     endif
-    highlights->add(from_def->extend({name: new_group})->extend(new_attrs))
+    highlights->add(from_def->extend({name: new_group, default: true})->extend(new_attrs))
     highlights->hlset()
 
     # Make sure  the derived highlight groups  persist even if the  color scheme


### PR DESCRIPTION
Currently it is impossible to rewrite or link highlights created with the help of Derive() function.
Adding `default: true` attribute to sethl() function fixes this.