### PR TITLE
Allow legacy comment before vim9script statement

### DIFF
--- a/syntax/vim.vim
+++ b/syntax/vim.vim
@@ -6,6 +6,11 @@ vim9script noclear
 if (exists('b:current_syntax')
         # bail out for a file written in legacy Vim script
         || "\n" .. getline(1, 10)->join("\n") !~ '\nvim9\%[script]\>'
+        # Or if legacy Vim script comment used at the start of the script
+        # vim9 scripts can start with legacy script to check for vim9 support
+        # This avoids highlighting much of the file as a single vim9 string
+        || "\n" .. getline(1, 10)->join("\n") =~ '\n\s*".*\nvim9\%[script]\>'
+        #
         # Bail out if we're included from another filetype (e.g. `markdown`).{{{
         #
         # Rationale: If we're  included, we don't  know which type of  syntax does


### PR DESCRIPTION
It is possible to check for vim9script support using legacy script, e.g.

```vim
    if !has('vim9script')
      finish
    endif
    vim9script
```

If a legacy comment is used before vim9script this can mess up syntax highlighting, leaving much of the file highlighted as a single string. Fix by adding crude check for legacy comment before vimscript statement.

There's probably a better way to fix this, but the crude check and fallback to standard vim syntax does the job for me.

Example of file with legacy comment that causes this problem:
https://github.com/yegappan/lsp/blob/main/plugin/lsp.vim

**Screenshot before:**
<img width="425" height="372" alt="Screenshot 2026-01-05 at 10 07 54" src="https://github.com/user-attachments/assets/7f2af6f2-fc5e-40ae-a400-a8f81ee7b4c5" />

**Screenshot after:**
<img width="402" height="379" alt="Screenshot 2026-01-05 at 10 08 27" src="https://github.com/user-attachments/assets/88d3868a-6819-4516-a4c8-07432c375a91" />
